### PR TITLE
Replace sizeof with lastindex

### DIFF
--- a/src/passes.jl
+++ b/src/passes.jl
@@ -225,7 +225,7 @@ end
 
 
 function lineends_pass(text, x, state)
-    n = sizeof(text)
+    n = lastindex(text)
     io = IOBuffer(reverse(text))
     while !eof(io)
         c = read(io, Char)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,7 +20,7 @@ function get_lines(s::String)
             push!(lines, (position(io), readindent(io)))
         end
     end
-    first(last(lines)) != sizeof(s) && push!(lines, (sizeof(s), 0))
+    first(last(lines)) != lastindex(s) && push!(lines, (lastindex(s), 0))
     lines
 end
 


### PR DESCRIPTION
Those are all instances of `sizeof` in this package. I'm fairly positive that they should all be replaced with `lastindex`, but not 100% sure, so would be great if @ZacLN could review carefully :)