### PR TITLE
Move to no spaces around kwargs by default, add config opt

### DIFF
--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -5,7 +5,7 @@ import CSTParser.Tokenize.Tokens
 using CSTParser: typof, kindof, EXPR
 using FilePathsBase
 
-const default_options = (4, true, true, true, true, true, true, true, true, false, true)
+const default_options = (4, true, true, true, true, true, true, true, true, false, true, 0)
 
 struct FormatOptions
     indent::Int
@@ -18,7 +18,8 @@ struct FormatOptions
     comments::Bool
     docs::Bool
     lineends::Bool
-    kw::Bool
+    keywords::Bool
+    kwarg::Int # Options arg (0 => no spacing around kw assignment, 1 => single space around kw assignment, anything else => off)
 end
 FormatOptions() = FormatOptions(default_options...)
 
@@ -75,7 +76,7 @@ function format(original_text::AbstractString, formatopts::FormatOptions = Forma
         state.offset = 0
         pass(x, state, doc_pass)
     end
-    if formatopts.kw
+    if formatopts.keywords
         state.offset = 0
         pass(x, state, kw_pass)
     end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -86,8 +86,13 @@ function call_pass(x, state)
             # space holder for splitting calls across lines
         end
     elseif typof(x) === CSTParser.Kw
-        ensure_single_space_after(x.args[1], state, state.offset)
-        ensure_single_space_after(x.args[2], state, state.offset + x.args[1].fullspan)
+        if state.opts.kwarg == 0
+            ensure_no_space_after(x.args[1], state, state.offset)
+            ensure_no_space_after(x.args[2], state, state.offset + x.args[1].fullspan)
+        elseif state.opts.kwarg == 1
+            ensure_exactly_single_space_after(x.args[1], state, state.offset)
+            ensure_exactly_single_space_after(x.args[2], state, state.offset + x.args[1].fullspan)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using DocumentFormat: format, isformatted
+using DocumentFormat: format, isformatted, FormatOptions
 using FilePathsBase
 using Test
 
@@ -115,7 +115,15 @@ using Test
         @test format("func(a, b; c)") == "func(a, b; c)"
         @test format("func(  a, b; c)") == "func(a, b; c)"
         @test format("func(a  ,b; c)") == "func(a, b; c)"
-        @test format("func(a=1,b; c=1)") == "func(a = 1, b; c = 1)"
+        @test format("func(a=1,b; c=1)") == "func(a=1, b; c=1)"
+        @testset "kwarg spacing" begin
+            @test format("f(a=1)", FormatOptions(4, true, true, true, true, true, true, true, true, false, true, 0)) == "f(a=1)"
+            @test format("f(a = 1)", FormatOptions(4, true, true, true, true, true, true, true, true, false, true, 0)) == "f(a=1)"
+            @test format("f(a=1)", FormatOptions(4, true, true, true, true, true, true, true, true, false, true, 1)) == "f(a = 1)"
+            @test format("f(a = 1)", FormatOptions(4, true, true, true, true, true, true, true, true, false, true, 1)) == "f(a = 1)"
+            @test format("f(a = 1)", FormatOptions(4, true, true, true, true, true, true, true, true, false, true, 34)) == "f(a = 1)"
+            @test format("f(a =   1)", FormatOptions(4, true, true, true, true, true, true, true, true, false, true, 34)) == "f(a =   1)"
+        end
     end
 
     @testset "indents" begin
@@ -517,7 +525,7 @@ end"""
 """
 
         original_should = """
-function bar(x,  y   =  3)
+function bar(x,  y=3)
 end
 """
 
@@ -537,7 +545,7 @@ end
         end
 
     end
-    @testset "kw format" begin
+    @testset "keyword format" begin
         @test format("function  f end") == "function f end"
         @test format("function f end") == "function f end"
     end


### PR DESCRIPTION
closes #102 
Adds missing config option for spacing around kw-args. Default is for no spaces.

Version bump (major?) required as it affects external facing interface.

FI @non-Jedi 