### PR TITLE
Format anonymous functions correctly

### DIFF
--- a/src/passes.jl
+++ b/src/passes.jl
@@ -1,6 +1,6 @@
 function operator_pass(x, state)
     if typof(x) === CSTParser.BinaryOpCall
-        if CSTParser.precedence(x.args[2]) in (8, 13, 14, 16) || x.args[2].fullspan == 0
+        if (CSTParser.precedence(x.args[2]) in (8, 13, 14, 16) && x.args[2].kind !== CSTParser.Tokens.ANON_FUNC) || x.args[2].fullspan == 0
             ensure_no_space_after(x.args[1], state, state.offset)
             ensure_no_space_after(x.args[2], state, state.offset + x.args[1].fullspan)
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -549,4 +549,7 @@ end
         @test format("function  f end") == "function f end"
         @test format("function f end") == "function f end"
     end
+    @testset "anonymous function" begin
+        @test format("x->foo") == "x -> foo"
+    end
 end


### PR DESCRIPTION
This PR adds a check for the anonymous function case so that spaces are placed around the `->` operator.

Closes #108.