### PR TITLE
only format \s and \t in tuples

### DIFF
--- a/src/passes.jl
+++ b/src/passes.jl
@@ -45,10 +45,14 @@ function tuple_pass(x, state)
         n = length(x)
         for (i, a) in enumerate(x)
             i == n && continue
-            if headof(a) === :COMMA && !(CSTParser.ispunctuation(x[i + 1]))
-                ensure_single_space_after(a, state, offset)
-            elseif !(headof(x[i + 1]) === :parameters)
-                ensure_no_space_after(a, state, offset)
+            wsrange = offset + a.span + 1:offset + a.fullspan
+            ws = state.text[wsrange]
+            if all(in((' ', '\t')), ws)
+                if headof(a) === :COMMA && !(CSTParser.ispunctuation(x[i + 1]))
+                    ensure_single_space_after(a, state, offset)
+                elseif !(headof(x[i + 1]) === :parameters)
+                    ensure_no_space_after(a, state, offset)
+                end
             end
             offset += a.fullspan
         end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -45,7 +45,7 @@ function tuple_pass(x, state)
         n = length(x)
         for (i, a) in enumerate(x)
             i == n && continue
-            wsrange = offset + a.span + 1:offset + a.fullspan
+            wsrange = nextind(state.text, offset + a.span):offset + a.fullspan
             ws = state.text[wsrange]
             if all(in((' ', '\t')), ws)
                 if headof(a) === :COMMA && !(CSTParser.ispunctuation(x[i + 1]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,9 @@ using Test
         @test format("( π, 汉)") == "(π, 汉)"
         @test format("(π, 汉 )") == "(π, 汉)"
         @test format("(π, 汉 )") == "(π, 汉)"
+        @test format("(π, 汉 )") == "(π, 汉)"
+        @test format("(1, #= comment =# 3 )") == "(1, #= comment =# 3)"
+        @test format("(\n# comment\n1, \n# comment \n3\n# comment\n)") == "(\n# comment\n1, \n# comment \n3\n# comment\n)"
     end
     @testset "curly" begin
         @test format("X{a,b}") == "X{a,b}"


### PR DESCRIPTION
to preserve meaningful whitespace like new lines and comments.

Fixes https://github.com/julia-vscode/julia-vscode/issues/1862.