### PR TITLE
inner constructor

### DIFF
--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -20,6 +20,9 @@ struct FormatOptions
     lineends::Bool
     keywords::Bool
     kwarg::String # Options arg-> "none", "single", "off"
+
+    FormatOptions(indent::Int, indents::Bool, ops::Bool, tuples::Bool, curly::Bool, calls::Bool, iterOps::Bool, comments::Bool, docs::Bool, lineends::Bool, keywords::Bool, kwarg::String) =
+        new(indent, indents, ops, tuples, curly, calls, iterOps, comments, docs, lineends, keywords, kwarg)
 end
 FormatOptions() = FormatOptions(default_options...)
 


### PR DESCRIPTION
The changed definition in https://github.com/julia-vscode/DocumentFormat.jl/pull/127 is exactly the same as the default (Julia-provided) constructor for `FormatOptions`, so this gets rid of the method overwritten warning (and a potential stack overflow).