### PR TITLE
fix constructor on 32bit OSs

### DIFF
--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -5,10 +5,10 @@ import CSTParser.Tokenize.Tokens
 using CSTParser: headof, valof, EXPR
 using FilePathsBase
 
-const default_options = (4, true, true, true, true, true, true, true, true, false, true, "none")
+const default_options = (Int64(4), true, true, true, true, true, true, true, true, false, true, "none")
 
 struct FormatOptions
-    indent::Int
+    indent::Int64
     indents::Bool
     ops::Bool
     tuples::Bool
@@ -26,7 +26,7 @@ end
 # Any nothing argument is given a sane default value.
 FormatOptions() = FormatOptions(default_options...)
 function FormatOptions(
-        indent::Union{Nothing,Int},
+        indent::Union{Nothing,Int64},
         indents::Union{Nothing,Bool},
         ops::Union{Nothing,Bool},
         tuples::Union{Nothing,Bool},

--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -5,10 +5,10 @@ import CSTParser.Tokenize.Tokens
 using CSTParser: headof, valof, EXPR
 using FilePathsBase
 
-const default_options = (Int64(4), true, true, true, true, true, true, true, true, false, true, "none")
+const default_options = (4, true, true, true, true, true, true, true, true, false, true, "none")
 
 struct FormatOptions
-    indent::Int64
+    indent::Integer
     indents::Bool
     ops::Bool
     tuples::Bool
@@ -26,7 +26,7 @@ end
 # Any nothing argument is given a sane default value.
 FormatOptions() = FormatOptions(default_options...)
 function FormatOptions(
-        indent::Union{Nothing,Int64},
+        indent::Union{Nothing,Integer},
         indents::Union{Nothing,Bool},
         ops::Union{Nothing,Bool},
         tuples::Union{Nothing,Bool},


### PR DESCRIPTION
Hopefully fixes https://github.com/julia-vscode/crashreporting-issues/issues/30. Couldn't repro the bug on a 32bit install of Julia with this patch.

For every PR, please check the following:
- [x] End-user documentation check. If this PR requires end-user documentation in the Julia VS Code extension docs, please add that at https://github.com/julia-vscode/docs.
- [x] Changelog mention. If this PR should be mentioned in the CHANGELOG for the Julia VS Code extension, please open a PR against https://github.com/julia-vscode/julia-vscode/blob/master/CHANGELOG.md with those changes.
